### PR TITLE
Remove markers using hash instead of LatLng pair; support for multiple gm-markers inside gm-map

### DIFF
--- a/src/controllers/angulargmMapController.js
+++ b/src/controllers/angulargmMapController.js
@@ -221,6 +221,7 @@
 
     /**
      * Adds a new marker to the map.
+     * @param {number} scope id
      * @param {google.maps.MarkerOptions} markerOptions
      * @return {boolean} true if a marker was added, false if there was already
      *   a marker at this position. 'at this position' means delta_lat and
@@ -228,7 +229,7 @@
      * @throw if markerOptions does not have all required options (i.e. position)
      * @ignore
      */
-    this.addMarker = function(markerOptions) {
+    this.addMarker = function(scopeId, markerOptions) {
       var opts = {};
       angular.extend(opts, markerOptions);
 
@@ -238,43 +239,48 @@
 
       var marker = new google.maps.Marker(opts);
       var position = marker.getPosition();
-      if (this.hasMarker(position.lat(), position.lng())) {
+      if (this.hasMarker(scopeId, position.lat(), position.lng())) {
         return false;
       }
       
       var hash = position.toUrlValue(this.precision);
-      this._markers[hash] = marker;
+      if (this._markers[scopeId] == null) {
+          this._markers[scopeId] = {};
+      }
+      this._markers[scopeId][hash] = marker;
       marker.setMap(this._map);
       return true;
     };      
 
 
     /**
+     * @param {number} scope id
      * @param {number} lat
      * @param {number} lng
      * @return {boolean} true if there is a marker with the given lat and lng
      * @ignore
      */
-    this.hasMarker = function(lat, lng) {
-      return (this.getMarker(lat, lng) instanceof google.maps.Marker);
+    this.hasMarker = function(scopeId, lat, lng) {
+      return (this.getMarker(scopeId, lat, lng) instanceof google.maps.Marker);
     };
 
 
     /**
+     * @param {number} scope id
      * @param {number} lat
      * @param {number} lng
      * @return {google.maps.Marker} the marker at given lat and lng, or null if
      *   no such marker exists
      * @ignore
      */
-    this.getMarker = function (lat, lng) {
+    this.getMarker = function (scopeId, lat, lng) {
       if (lat == null || lng == null)
         throw 'lat or lng was null';
 
       var latLng = new google.maps.LatLng(lat, lng);
       var hash = latLng.toUrlValue(this.precision);
-      if (hash in this._markers) {
-        return this._markers[hash];
+      if (this._markers[scopeId] != null && hash in this._markers[scopeId]) {
+        return this._markers[scopeId][hash];
       } else {
         return null;
       }
@@ -282,45 +288,39 @@
 
 
     /**
+     * @param {number} scope id
      * @param {number} lat
      * @param {number} lng
      * @return {boolean} true if a marker was removed, false if nothing
      *   happened
      * @ignore
      */
-    this.removeMarker = function(lat, lng) {
+    this.removeMarker = function(scopeId, lat, lng) {
       if (lat == null || lng == null)
         throw 'lat or lng was null';
 
       var latLng = new google.maps.LatLng(lat, lng);
 
-      var removed = false;
       var hash = latLng.toUrlValue(this.precision);
-      var marker = this._markers[hash];
-      if (marker) {
-        marker.setMap(null);
-        removed = true;
-      }
-      this._markers[hash] = null;
-      delete this._markers[hash];
-      return removed;
+      return this.removeMarkerByHash(scopeId, hash);
     };
 
     /**
      *
+     * @param {number} scope id
      * @param {string} hash
      * @returns {boolean} true if a marker was removed, false if nothing
      *   happened
      */
-    this.removeMarkerByHash = function(hash) {
+    this.removeMarkerByHash = function(scopeId, hash) {
         var removed = false;
-        var marker = this._markers[hash];
+        var marker = this._markers[scopeId][hash];
         if (marker) {
             marker.setMap(null);
             removed = true;
         }
-        this._markers[hash] = null;
-        delete this._markers[hash];
+        this._markers[scopeId][hash] = null;
+        delete this._markers[scopeId][hash];
         return removed;
     };
 
@@ -353,11 +353,43 @@
      */
     this.forEachMarker = function(fn) {
       if (fn == null) { throw 'fn was null or undefined'; }
-      angular.forEach(this._markers, function(marker, hash) {
+      var that = this;
+      var allMarkers = Object.keys(this._markers).reduce(function(markers, key){
+          angular.forEach(that._markers[key], function(marker){
+              markers.push(marker);
+          });
+          return markers;
+      }, []);
+      angular.forEach(allMarkers, function(marker, hash) {
         if (marker != null) {
           fn(marker, hash);
         }
       });
+    };
+
+
+    /**
+     * Applies a function to each marker.
+     * @param {number} scope id
+     * @param {Function} fn will called with marker as first argument
+     * @throw if fn is null or undefined
+     * @ignore
+     */
+    this.forEachMarkerInScope = function(scopeId, fn) {
+        if (fn == null) { throw 'fn was null or undefined'; }
+        angular.forEach(this._markers[scopeId], function(marker, hash) {
+            if (marker != null) {
+                fn(marker, hash);
+            }
+        });
+    };
+
+    /**
+     * Get current map.
+     * @returns {object}
+     */
+    this.getMap = function() {
+        return this._map;
     };
 
     /** Instantiate controller */

--- a/src/directives/gmMarkers.js
+++ b/src/directives/gmMarkers.js
@@ -138,7 +138,7 @@
       });
 
       // fn for updating markers from objects
-      var updateMarkers = function(objects) {
+      var updateMarkers = function(scope, objects) {
 
         var objectHash = {};
 
@@ -156,13 +156,13 @@
           objectHash[hash] = object;
 
           // add marker
-          if (!controller.hasMarker(latLngObj.lat, latLngObj.lng)) {
+          if (!controller.hasMarker(scope.$id, latLngObj.lat, latLngObj.lng)) {
 
             var options = {};
             angular.extend(options, markerOptions, {position: position});
 
-            controller.addMarker(options);
-            var marker = controller.getMarker(latLngObj.lat, latLngObj.lng);
+            controller.addMarker(scope.$id, options);
+            var marker = controller.getMarker(scope.$id, latLngObj.lat, latLngObj.lng);
 
             // set up marker event handlers
             angular.forEach(handlers, function(handler, event) {
@@ -184,14 +184,14 @@
         // remove 'orphaned' markers
         var orphaned = [];
         
-        controller.forEachMarker(function(marker, hash) {
+        controller.forEachMarkerInScope(scope.$id, function(marker, hash) {
           if (!(hash in objectHash)) {
             orphaned.push(hash);
           }
         });
 
         angular.forEach(orphaned, function(markerHash, i) {
-          controller.removeMarkerByHash(markerHash);
+          controller.removeMarkerByHash(scope.$id, markerHash);
         });
 
         scope.$emit('gmMarkersUpdated', attrs.gmObjects);
@@ -200,13 +200,13 @@
       // watch objects
       scope.$watch('gmObjects().length', function(newValue, oldValue) {
         if (newValue != null && newValue !== oldValue) {
-          updateMarkers(scope.gmObjects());
+          updateMarkers(scope, scope.gmObjects());
         }
       });
 
       scope.$watch('gmObjects()', function(newValue, oldValue) {
         if (newValue != null && newValue !== oldValue) {
-          updateMarkers(scope.gmObjects());
+          updateMarkers(scope, scope.gmObjects());
         }
       });
 
@@ -217,7 +217,7 @@
             var event = eventObj.event;
             var locations = eventObj.locations;
             angular.forEach(locations, function(location) {
-              var marker = controller.getMarker(location.lat(), location.lng());
+              var marker = controller.getMarker(scope.$id, location.lat(), location.lng());
               if (marker != null) {
                 $timeout(angular.bind(this, controller.trigger, marker, event));
               }
@@ -228,13 +228,13 @@
 
       scope.$on('gmMarkersRedraw', function(event, objectsName) {
         if (objectsName === attrs.gmObjects) {
-          updateMarkers();          
-          updateMarkers(scope.gmObjects());
+          updateMarkers(scope);
+          updateMarkers(scope, scope.gmObjects());
         }
       });
 
       // initialize markers
-      $timeout(angular.bind(null, updateMarkers, scope.gmObjects()));
+      $timeout(angular.bind(null, updateMarkers, scope, scope.gmObjects()));
     }
 
 

--- a/test/unit/controllers/angulargmMapController.js
+++ b/test/unit/controllers/angulargmMapController.js
@@ -145,6 +145,8 @@ describe('angulargmMapController', function() {
       positionVeryClose = new google.maps.LatLng(1.0005, 2.0005);
       position2 = new google.maps.LatLng(3, 4);
 
+      scope = 'scope';
+
       markerOptions = {
         position: position
       };
@@ -158,31 +160,31 @@ describe('angulargmMapController', function() {
         position: position2
       };
 
-      mapCtrl.addMarker(markerOptions);
+      mapCtrl.addMarker(scope, markerOptions);
     });
 
     describe('addMarker', function() {
 
       it('adds new markers to the map', function() {
-        added = mapCtrl.addMarker(markerOptions2);
+        added = mapCtrl.addMarker(scope, markerOptions2);
         expect(added).toBeTruthy();
       });
 
       
       it('does not add markers already on the map', function() {
-        var added = mapCtrl.addMarker(markerOptions);
+        var added = mapCtrl.addMarker(scope, markerOptions);
         expect(added).toBeFalsy();
       });
 
 
       it('adds markers which differ by at least 0.0005', function() {
-        var added = mapCtrl.addMarker(markerOptionsVeryClose);
+        var added = mapCtrl.addMarker(scope, markerOptionsVeryClose);
         expect(added).toBeTruthy();
       });
 
 
       it('does not add markers which differ less than 0.0005', function() {
-        var added = mapCtrl.addMarker(markerOptionsSame);
+        var added = mapCtrl.addMarker(scope, markerOptionsSame);
         expect(added).toBeFalsy();
       });
 
@@ -192,25 +194,25 @@ describe('angulargmMapController', function() {
     describe('getMarker', function() {
 
       it('retrieves markers that are on the map', function() {
-        var marker = mapCtrl.getMarker(position.lat(), position.lng());
+        var marker = mapCtrl.getMarker(scope, position.lat(), position.lng());
         expect(marker.getPosition()).toEqual(markerOptions.position);
       });
 
 
       it('returns null for marker not on the map', function() {
-        var marker = mapCtrl.getMarker(position2.lat(), position2.lng());
+        var marker = mapCtrl.getMarker(scope, position2.lat(), position2.lng());
         expect(marker).toBeNull();
       });
 
 
       it('retrives markers given a lat and lng that are within 0.0005', function() {
-        var marker = mapCtrl.getMarker(positionSame.lat(), positionSame.lng());
+        var marker = mapCtrl.getMarker(scope, positionSame.lat(), positionSame.lng());
         expect(marker.getPosition()).toEqual(markerOptions.position);
       });
 
 
       it('does not retrieve marker given lat and lng more than 0.0005 away', function() {
-        var marker = mapCtrl.getMarker(positionVeryClose.lat(), positionVeryClose.lng());
+        var marker = mapCtrl.getMarker(scope, positionVeryClose.lat(), positionVeryClose.lng());
         expect(marker).toBeNull();
       });
 
@@ -220,16 +222,16 @@ describe('angulargmMapController', function() {
     describe('removeMarker', function() {
 
       it('removes markers from the map', function() {
-        var removed = mapCtrl.removeMarker(position.lat(), position.lng());
+        var removed = mapCtrl.removeMarker(scope, position.lat(), position.lng());
         expect(removed).toBeTruthy();
-        expect(mapCtrl.getMarker(position.lat(), position.lng())).toBeNull();
+        expect(mapCtrl.getMarker(scope, position.lat(), position.lng())).toBeNull();
       });
 
 
       it('does not remove markers not on the map', function() {
-        var removed = mapCtrl.removeMarker(position2.lat(), position2.lng());
+        var removed = mapCtrl.removeMarker(scope, position2.lat(), position2.lng());
         expect(removed).toBeFalsy();
-        expect(mapCtrl.getMarker(position.lat(), position.lng())).not.toBeNull();
+        expect(mapCtrl.getMarker(scope, position.lat(), position.lng())).not.toBeNull();
       });
 
     });
@@ -252,7 +254,7 @@ describe('angulargmMapController', function() {
 
 
     it('does not apply a function to removed markers', function() {
-      mapCtrl.removeMarker(1, 2);
+      mapCtrl.removeMarker(scope, 1, 2);
       var called = false;
       mapCtrl.forEachMarker(function(marker) {
         called = true;

--- a/test/unit/directives/gmMarkersSpec.js
+++ b/test/unit/directives/gmMarkersSpec.js
@@ -1,5 +1,5 @@
 describe('gmMarkers', function() {
-  var elm, scope, mapCtrl; 
+  var elm, scope, markersScopeId, mapCtrl;
   var objToLatLng;
   var $timeout;
 
@@ -44,8 +44,11 @@ describe('gmMarkers', function() {
     mapCtrl = gmtestMapController();
     spyOn(mapCtrl, 'addMarker').andCallThrough();
     spyOn(mapCtrl, 'removeMarker').andCallThrough();
+    spyOn(mapCtrl, 'removeMarkerByHash').andCallThrough();
     spyOn(mapCtrl, 'trigger').andCallThrough();
     spyOn(mapCtrl, 'addListener').andCallThrough();
+
+    markersScopeId = elm.find('gm-markers').scope().$id;
 
     scope.$digest();
     $timeout.flush();
@@ -90,8 +93,8 @@ describe('gmMarkers', function() {
     it('initializes markers with objects', function() {
       var position1 = objToLatLng(scope.people[0]);
       var position2 = objToLatLng(scope.people[1]);
-      expect(mapCtrl.addMarker).toHaveBeenCalledWith({key: 'value', title: jasmine.any(String), position: position1});
-      expect(mapCtrl.addMarker).toHaveBeenCalledWith({key: 'value', title: jasmine.any(String), position: position2});
+      expect(mapCtrl.addMarker).toHaveBeenCalledWith(markersScopeId, {key: 'value', title: jasmine.any(String), position: position1});
+      expect(mapCtrl.addMarker).toHaveBeenCalledWith(markersScopeId, {key: 'value', title: jasmine.any(String), position: position2});
     });
 
     
@@ -99,7 +102,7 @@ describe('gmMarkers', function() {
       scope.people.push({name: '6', lat: 7, lng: 8});
       var position = objToLatLng(scope.people[2]);
       scope.$digest();
-      expect(mapCtrl.addMarker).toHaveBeenCalledWith({key: 'value', title: jasmine.any(String), position: position});
+      expect(mapCtrl.addMarker).toHaveBeenCalledWith(markersScopeId, {key: 'value', title: jasmine.any(String), position: position});
     });
 
 
@@ -110,7 +113,7 @@ describe('gmMarkers', function() {
         scope.people.push({name: 'new' + i, lat: i, lng: i});
       }
       scope.$digest();
-      expect(mapCtrl.removeMarker.calls.length).toEqual(length);
+      expect(mapCtrl.removeMarkerByHash.calls.length).toEqual(length);
       expect(mapCtrl.addMarker.calls.length).toEqual(length * 2);
     });
 
@@ -118,7 +121,8 @@ describe('gmMarkers', function() {
     it('updates markers with removed objects', function() {
       var person = scope.people.pop();
       scope.$digest();
-      expect(mapCtrl.removeMarker).toHaveBeenCalledWith(person.lat, person.lng);
+      var position = new google.maps.LatLng(person.lat, person.lng);
+      expect(mapCtrl.removeMarkerByHash).toHaveBeenCalledWith(markersScopeId, position.toUrlValue(mapCtrl.precision));
     });
 
 
@@ -141,8 +145,8 @@ describe('gmMarkers', function() {
 
 
   it('retrieves marker options', function() {
-    expect(mapCtrl.addMarker).toHaveBeenCalledWith({key: 'value', title: '0', position: jasmine.any(Object)});
-    expect(mapCtrl.addMarker).toHaveBeenCalledWith({key: 'value', title: '3', position: jasmine.any(Object)});
+    expect(mapCtrl.addMarker).toHaveBeenCalledWith(markersScopeId, {key: 'value', title: '0', position: jasmine.any(Object)});
+    expect(mapCtrl.addMarker).toHaveBeenCalledWith(markersScopeId, {key: 'value', title: '3', position: jasmine.any(Object)});
   });
 
 
@@ -208,7 +212,7 @@ describe('gmMarkers', function() {
 
   it('calls event handlers when event fired', function() {
     var person = scope.people[0];
-    var marker = mapCtrl.getMarker(person.lat, person.lng);
+    var marker = mapCtrl.getMarker(markersScopeId, person.lat, person.lng);
     var handled = false;
     runs(function() {
       google.maps.event.addListener(marker, 'mouseover', function() {handled = true;});
@@ -236,8 +240,8 @@ describe('gmMarkers', function() {
     };
     scope.$broadcast('gmMarkersRedraw', 'people');
 
-    expect(mapCtrl.addMarker).toHaveBeenCalledWith({key: 'differentValue', title: jasmine.any(String), position: position1});
-    expect(mapCtrl.addMarker).toHaveBeenCalledWith({key: 'differentValue', title: jasmine.any(String), position: position2});
+    expect(mapCtrl.addMarker).toHaveBeenCalledWith(markersScopeId, {key: 'differentValue', title: jasmine.any(String), position: position1});
+    expect(mapCtrl.addMarker).toHaveBeenCalledWith(markersScopeId, {key: 'differentValue', title: jasmine.any(String), position: position2});
   });
 
 
@@ -250,8 +254,8 @@ describe('gmMarkers', function() {
     };
     scope.$broadcast('gmMarkersRedraw', 'otherObjects');
 
-    expect(mapCtrl.addMarker).not.toHaveBeenCalledWith({key: 'differentValue', title: jasmine.any(String), position: jasmine.any(Object)});
-    expect(mapCtrl.addMarker).not.toHaveBeenCalledWith({key: 'differentValue', title: jasmine.any(String), position: jasmine.any(Object)});
+    expect(mapCtrl.addMarker).not.toHaveBeenCalledWith(markersScopeId, {key: 'differentValue', title: jasmine.any(String), position: jasmine.any(Object)});
+    expect(mapCtrl.addMarker).not.toHaveBeenCalledWith(markersScopeId, {key: 'differentValue', title: jasmine.any(String), position: jasmine.any(Object)});
   });
 
   it('emits marker update event when markers updated', function() {


### PR DESCRIPTION
It is possible to change `latitude` and `longitude` properties of already added markers (e.g. after dragging). These markers won't get cleaned after next updateMarkers iteration, cause new computed hash will be different from old one. Now cleanup of orphaned objects is performed using old hash values.
