### PR TITLE
Add option to override the Marker constructor.

### DIFF
--- a/src/controllers/angulargmMapController.js
+++ b/src/controllers/angulargmMapController.js
@@ -243,7 +243,7 @@
         throw 'markerOptions did not contain a position';
       }
 
-      var marker = new google.maps.Marker(opts);
+      var marker = new angulargmDefaults.markerConstructor(opts);
       var position = marker.getPosition();
       if (this.hasMarker(scopeId, position.lat(), position.lng())) {
         return false;

--- a/src/module.js
+++ b/src/module.js
@@ -46,6 +46,7 @@
    * @module angulargmDefaults
    */
   value('angulargmDefaults', {
+    'markerConstructor': google.maps.Marker,
     'mapOptions': {
       zoom : 8,
       center : new google.maps.LatLng(46, -120),


### PR DESCRIPTION
This enables you to use alternative Marker implementations e.g.

http://google-maps-utility-library-v3.googlecode.com/svn-history/r161/trunk/styledmarker/docs/examples.html
