### PR TITLE
Resize must be triggered before MapOptions are resetted

### DIFF
--- a/src/controllers/angulargmMapController.js
+++ b/src/controllers/angulargmMapController.js
@@ -130,6 +130,8 @@
       } else {
         var div = map.getDiv();
         element.replaceWith(div);
+        this._map = map;
+        this.mapTrigger('resize');
         map.setOptions(config);
       }
       return map;

--- a/src/directives/gmMap.js
+++ b/src/directives/gmMap.js
@@ -159,8 +159,6 @@
           controller.mapTrigger('resize');
         }
       });
-
-      controller.mapTrigger('resize');
     }
 
 


### PR DESCRIPTION
It fix an issue when a map is reused with a different size, the center was calculated on the size of the map loaded previously.
