### PR TITLE
Remove ngTransclude attr causing issue in Angular 1.2.15+

### DIFF
--- a/src/directives/gmMap.js
+++ b/src/directives/gmMap.js
@@ -255,7 +255,7 @@
       priority: 100,
       template: '<div>' +
                   '<div id="" style="width:100%;height:100%;"></div>' +
-                  '<div ng-transclude></div>' +
+                  '<div></div>' +
                 '</div>',
       transclude: true,
       replace: true,


### PR DESCRIPTION
From the doc:

> Occurs when an ngTransclude occurs without a transcluded ancestor element.
> 
> This error often occurs when you have forgotten to set transclude: true in some directive definition, and then used ngTransclude in the directive's template.
> 
> To resolve, either remove the offending ngTransclude or check that transclude: true is included in the intended directive definition.

[http://docs.angularjs.org/error/ngTransclude/orphan?p0=](http://docs.angularjs.org/error/ngTransclude/orphan?p0=)
