### PR TITLE
Conditionally compile the infowindow contents

### DIFF
--- a/src/directives/gmInfoWindow.js
+++ b/src/directives/gmInfoWindow.js
@@ -74,7 +74,12 @@
 
       //Decorate infoWindow.open to $compile contents before opening
       var _open = infoWindow.open;
+      var compiled = false;
       infoWindow.open = function open(map, anchor) {
+        if(!compiled){
+          $compile(element.contents())(scope);
+          compiled = true;
+        }
         _open.call(infoWindow, map, anchor);
       };
     }


### PR DESCRIPTION
The compilation of the info window is extremely useful and adding a simple bool check avoids the problem described in #27.
