### PR TITLE
Fix mixed content errors in examples

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -3,7 +3,7 @@
 
   <head lang="en">
     <meta charset="utf-8">
-    <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
+    <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
     <link href="css/prettify.css" rel="stylesheet">
     <link href="css/docs.css" rel="stylesheet">
     <title>AngularGM Examples</title>
@@ -43,11 +43,11 @@
 
     <div ng-view class="examples-container"></div>
 
-    <script src="http://maps.googleapis.com/maps/api/js?key=AIzaSyBcP7K4Ul9dlaI63GMg2kmy1XOth7FKXKw"></script>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
-    <script src="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js"></script>
-    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.6.1/angular.min.js"></script>
-    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.6.1/angular-route.min.js"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBcP7K4Ul9dlaI63GMg2kmy1XOth7FKXKw"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+    <script src="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.6.1/angular.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.6.1/angular-route.min.js"></script>
 
     <script src="js/prettify.min.js"></script>
     <script src="js/homepage.js"></script>


### PR DESCRIPTION
Thanks for the directives!

I noticed the examples aren't working on GH pages because of mixed content errors. Here's a small pull to address that. I'd be happy to update the gh-pages branch, too, if you'd like.