### PR TITLE
Support passing an optional objectId to gmMarkersUpdate to update only the marker associated with that object

### DIFF
--- a/src/directives/gmMarkers.js
+++ b/src/directives/gmMarkers.js
@@ -104,9 +104,20 @@
  * directive. If not specified, all instances of `gmMarkers` which are child
  * scopes will update their markers.
  *
+ * @param {string} objectId Not required. The id of one item from `gm-objects`
+ * that has been updated. If provided along with the objects param, only the
+ * marker for the one object with that id will be updated. If not provided,
+ * all markers will be updated as usual. It can be useful to avoid updating all
+ * the markers in a large list after each update when only a single object has
+ * changed.
+ *
  * @example
  * ```js
+ * $scope.$broadcast('gmMarkersUpdate');
+ * // or
  * $scope.$broadcast('gmMarkersUpdate', 'myObjects');
+ * // or
+ * $scope.$broadcast('gmMarkersUpdate', 'myObjects', 'dk37d09blkd2h');
  * ```
  */
 

--- a/test/unit/directives/gmMarkersSpec.js
+++ b/test/unit/directives/gmMarkersSpec.js
@@ -23,7 +23,7 @@ describe('gmMarkers', function() {
     scope.mapId = 'test';
 
     $timeout = _$timeout_;
-    latLngToObj = angulargmUtils.latLngToObj
+    latLngToObj = angulargmUtils.latLngToObj;
 
     // compile angulargmMarkers directive
     elm = angular.element('<gm-map gm-map-id="mapId" gm-center="center" gm-zoom="zoom" gm-bounds="bounds">' +
@@ -158,13 +158,40 @@ describe('gmMarkers', function() {
 
 
     it('updates markers with changed objects when update triggered', function() {
-      var person = scope.people[0]
+      var person = scope.people[0];
+      var origLength = scope.people.length;
+      person.location.lat = person.location.lat + 5;
+      person.location.lng = person.location.lng + 5;
+      var newPosition = person.location;
+      scope.$broadcast('gmMarkersUpdate');
+      expect(mapCtrl.updateElement).toHaveBeenCalledWith('marker', markersScopeId,
+        jasmine.any(String), {key: 'value', title: jasmine.any(String), position: newPosition});
+      expect(mapCtrl.updateElement.calls.count()).toEqual(origLength);
+    });
+
+
+    it('updates markers with changed objects when update triggered when providing objectsName', function() {
+      var origLength = scope.people.length;
+      var person = scope.people[0];
       person.location.lat = person.location.lat + 5;
       person.location.lng = person.location.lng + 5;
       var newPosition = person.location;
       scope.$broadcast('gmMarkersUpdate', objectsName);
       expect(mapCtrl.updateElement).toHaveBeenCalledWith('marker', markersScopeId,
         jasmine.any(String), {key: 'value', title: jasmine.any(String), position: newPosition});
+      expect(mapCtrl.updateElement.calls.count()).toEqual(origLength);
+    });
+
+
+    it('updates markers with changed objects when update triggered when providing objectsName and objectId', function() {
+      var person = scope.people[0];
+      person.location.lat = person.location.lat + 5;
+      person.location.lng = person.location.lng + 5;
+      var newPosition = person.location;
+      scope.$broadcast('gmMarkersUpdate', objectsName, person.id);
+      expect(mapCtrl.updateElement).toHaveBeenCalledWith('marker', markersScopeId,
+        person.id, {key: 'value', title: jasmine.any(String), position: newPosition});
+      expect(mapCtrl.updateElement.calls.count()).toEqual(1);
     });
 
 


### PR DESCRIPTION
Hi,

I have a map with hundreds-to-thousands of markers in a single gmMarkers directive. I get location updates for individual markers quite frequently--sometimes more than one per second. I had been notifying AngularGM of the update with ```$scope.$broadcast('gmMarkersUpdate', 'objectsName')```, but as the number of markers and frequency of updates increased, CPU usage of the app started to become a problem. I wanted a way to tell AngularGM to update a single marker whose associated object had been changed without having to go through all the markers in the directive.

Here's an attempt to do that. It seems to work well for my needs.

I made Plunkers to demonstrate the before (http://plnkr.co/edit/dnmmcOmeTcpgImONKFOW?p=preview) and after (http://plnkr.co/edit/o7AxQjlfWo4uopcojDBr?p=preview) behavior. Looking at Chrome's task manager, CPU usage seems to be reduced. Here are screenshots Chrome's profiler over 5 seconds of updates: https://imgur.com/a/SB4Dz

I'd appreciate any feedback you have.

Thanks!
Matt