### PR TITLE
Allow custom marker constructors to be used for specific gmMarkers directives

### DIFF
--- a/examples/partials/markers.html
+++ b/examples/partials/markers.html
@@ -13,11 +13,11 @@
   height: 300px;
 }
 
-/* 
+/*
 Fixes Bootstrap issues with Google Maps
-see http://stackoverflow.com/a/9170756 
+see http://stackoverflow.com/a/9170756
 */
-.map img { 
+.map img {
   max-width: none;
 }
 
@@ -43,7 +43,7 @@ img.volcano {
         icon: 'https://maps.gstatic.com/mapfiles/ms2/micons/yellow-dot.png',
       }
     };
-    
+
     $scope.volcanoes = [
       {
         id: 0,
@@ -51,7 +51,7 @@ img.volcano {
         img: 'http://www.thetrackerfoundation.org/Images/MountRainier_SM.jpg',
         elevationMeters: 4392,
         location: {
-          lat: 46.852947, 
+          lat: 46.852947,
           lng: -121.760424
         }
       },
@@ -61,7 +61,7 @@ img.volcano {
         img: 'http://www.destination360.com/north-america/us/washington/images/s/washington-mt-baker-ski.jpg',
         elevationMeters: 3287,
         location: {
-          lat: 48.776797, 
+          lat: 48.776797,
           lng: -121.814467
         }
       },
@@ -71,7 +71,7 @@ img.volcano {
         img: 'http://www.rhinoclimbs.com/Images/Glacier.9.jpg',
         elevationMeters: 3207,
         location: {
-          lat: 48.111844, 
+          lat: 48.111844,
           lng: -121.11412
         }
       }
@@ -84,7 +84,7 @@ img.volcano {
           $scope.options.notselected
       );
     };
-    
+
     $scope.selectVolcano = function(volcano) {
       if ($scope.volcano) {
         $scope.volcano.selected = false;
@@ -99,7 +99,7 @@ img.volcano {
 <script type="text/ng-template" id="map_with_markers.html">
   <div ng-controller="MapWithMarkersCtrl">
     <div>
-      <gm-map gm-map-id="'mapWithMarkers'" gm-center="center" 
+      <gm-map gm-map-id="'mapWithMarkers'" gm-center="center"
               gm-zoom="zoom" gm-map-options="options.map" class="map">
 
         <gm-markers gm-objects="volcanoes"
@@ -139,11 +139,11 @@ img.volcano {
   height: 300px;
 }
 
-/* 
+/*
 Fixes Bootstrap issues with Google Maps
-see http://stackoverflow.com/a/9170756 
+see http://stackoverflow.com/a/9170756
 */
-.map img { 
+.map img {
   max-width: none;
 }
 </style>
@@ -151,14 +151,14 @@ see http://stackoverflow.com/a/9170756
   angular.module('drag-markers', ['AngularGM']).
 
   controller('DragMarkerCtrl', function($scope) {
-    
+
     $scope.houses = [
       {
         id: 0,
         name: 'House A',
         lat: 46,
         lng: -122
-      }, 
+      },
       {
         id: 1,
         name: 'House B',
@@ -166,7 +166,7 @@ see http://stackoverflow.com/a/9170756
         lng: -120
       }
     ];
-    
+
     $scope.options = {
       map: {
         center: new google.maps.LatLng(46, -122),
@@ -181,7 +181,7 @@ see http://stackoverflow.com/a/9170756
         }
       }
     };
-    
+
     $scope.setHouseLocation = function(house, marker) {
       var position = marker.getPosition();
       house.lat = position.lat();
@@ -193,7 +193,7 @@ see http://stackoverflow.com/a/9170756
 <script type="text/ng-template" id="drag_markers.html">
   <div ng-controller="DragMarkerCtrl">
     <div>
-      <gm-map gm-map-id="'dragMarkerMap'" gm-center="center" gm-zoom="zoom" 
+      <gm-map gm-map-id="'dragMarkerMap'" gm-center="center" gm-zoom="zoom"
               gm-map-options="options.map" class="map">
 
         <gm-markers gm-objects="houses"
@@ -211,7 +211,7 @@ see http://stackoverflow.com/a/9170756
       </p>
       <p>
         <label ng-repeat="house in houses">
-          {{house.name}} location: {{house.lat | number:2}}, {{house.lng | number:2}} 
+          {{house.name}} location: {{house.lat | number:2}}, {{house.lng | number:2}}
         </label>
       </p>
     </div>
@@ -236,11 +236,11 @@ see http://stackoverflow.com/a/9170756
   height: 300px;
 }
 
-/* 
+/*
 Fixes Bootstrap issues with Google Maps
-see http://stackoverflow.com/a/9170756 
+see http://stackoverflow.com/a/9170756
 */
-.map img { 
+.map img {
   max-width: none;
 }
 
@@ -257,7 +257,7 @@ see http://stackoverflow.com/a/9170756
       gray: 'http://maps.gstatic.com/mapfiles/ridefinder-images/mm_20_gray.png',
       red: 'http://maps.gstatic.com/mapfiles/ridefinder-images/mm_20_red.png',
     }
-    
+
     $scope.options = {
       map: {
         center: new google.maps.LatLng(0, 0),
@@ -277,7 +277,7 @@ see http://stackoverflow.com/a/9170756
       male: true,
       female: true
     }
-   
+
     $scope.getMarkerOptions = function(person) {
       var opts = {title: person.name};
       if (person.id in $scope.filteredPeople) {
@@ -286,7 +286,7 @@ see http://stackoverflow.com/a/9170756
         return angular.extend(opts, $scope.options.unhighlighted);
       }
     };
-    
+
     $scope.filterPeople = function() {
       $scope.filteredPeople = {};
       angular.forEach($scope.people, function(person) {
@@ -300,7 +300,7 @@ see http://stackoverflow.com/a/9170756
       });
       $scope.$broadcast('gmMarkersUpdate', 'people');
     };
-    
+
     $scope.$watch('people', function() {
       $scope.filterPeople();
     });
@@ -310,8 +310,8 @@ see http://stackoverflow.com/a/9170756
 </script>
 <script type="text/ng-template" id="filter_markers.html">
   <div ng-controller="FilterMarkersCtrl">
-    <div>     
-      <gm-map gm-map-id="'filterMarkersMap'" gm-center="center" gm-zoom="zoom" 
+    <div>
+      <gm-map gm-map-id="'filterMarkersMap'" gm-center="center" gm-zoom="zoom"
               gm-map-options="options.map" class="map">
 
         <gm-markers gm-objects="people"
@@ -342,3 +342,197 @@ see http://stackoverflow.com/a/9170756
 
 
 
+<h1 id="custom-markers">Custom Markers</h1>
+<div class="row example">
+  <div class="span8 app-source" app-source="custom_markers.html custom_markers.js custom_markers.css" module="custom-markers"></div>
+  <div class="span4">
+    <span class="pull-right" js-fiddle="custom_markers.html custom_markers.js custom_markers.css" module="custom-markers"></span>
+    <div class="tabs-spacer"></div>
+    <div app-run="custom_markers.html" module="custom-markers" class="well"></div>
+  </div>
+</div>
+
+<style id="custom_markers.css">
+.map {
+  height: 300px;
+}
+
+/*
+Fixes Bootstrap issues with Google Maps
+see http://stackoverflow.com/a/9170756
+*/
+.map img {
+  max-width: none;
+}
+
+img.volcano {
+  height: 200px;
+  width: 250px;
+}
+
+.custom-marker {
+    background-color: blue;
+}
+
+.custom-marker.selected {
+    background-color: red;
+}
+</style>
+<script id="custom_markers.js">
+  angular.module('custom-markers', ['AngularGM'])
+
+  .controller('CustomMarkersCtrl', function($scope) {
+    var previousMarker;
+    $scope.options = {
+      map: {
+        center: new google.maps.LatLng(48, -121),
+        zoom: 6,
+        mapTypeId: google.maps.MapTypeId.TERRAIN
+      },
+      notselected: {
+        icon: 'https://maps.gstatic.com/mapfiles/ms2/micons/red-dot.png',
+      },
+      selected: {
+        icon: 'https://maps.gstatic.com/mapfiles/ms2/micons/yellow-dot.png',
+      }
+    };
+
+    $scope.volcanoes2 = [
+      {
+        id: 0,
+        name: 'Mount Rainier2',
+        img: 'http://www.thetrackerfoundation.org/Images/MountRainier_SM.jpg',
+        elevationMeters: 4392,
+        location: {
+          lat: 46.852947,
+          lng: -121.760424
+        }
+      },
+      {
+        id: 1,
+        name: 'Mount Baker2',
+        img: 'http://www.destination360.com/north-america/us/washington/images/s/washington-mt-baker-ski.jpg',
+        elevationMeters: 3287,
+        location: {
+          lat: 48.776797,
+          lng: -121.814467
+        }
+      },
+      {
+        id: 2,
+        name: 'Glacier Peak2',
+        img: 'http://www.rhinoclimbs.com/Images/Glacier.9.jpg',
+        elevationMeters: 3207,
+        location: {
+          lat: 48.111844,
+          lng: -121.11412
+        }
+      }
+    ];
+
+    $scope.getVolcanoOpts = function(volcano) {
+     return angular.extend(
+       { title: volcano.name },
+       volcano.selected ? $scope.options.selected :
+          $scope.options.notselected
+      );
+    };
+
+    $scope.selectVolcano = function(volcano, marker) {
+      if ($scope.volcano) {
+        $scope.volcano.selected = false;
+      }
+      $scope.volcano = volcano;
+      $scope.volcano.selected = true;
+      if (previousMarker) {
+        previousMarker.toggleSelected();
+      }
+      if (marker) {
+        marker.toggleSelected();
+      }
+      previousMarker = marker;
+
+      $scope.$broadcast('gmMarkersUpdate', 'volcanoes2');
+    };
+
+    function CustomMarker(options) {
+      if (options) {
+        if (options.position) {
+            this.latlng = new google.maps.LatLng(options.position.lat, options.position.lng);
+        }
+        this.div = document.createElement('div');
+        if (options.map) {
+            this.setMap(options.map);
+        }
+      }
+    }
+
+    CustomMarker.prototype = new google.maps.OverlayView();
+
+    CustomMarker.prototype.getDomElement = function getDomElement() {
+      return this.div;
+    };
+
+    CustomMarker.prototype.setOptions = function setOptions(options) {
+      this.latlng = new google.maps.LatLng(options.position.lat, options.position.lng);
+      this.draw();
+    };
+
+    CustomMarker.prototype.onAdd = function onAdd() {
+      this.div.className = 'custom-marker';
+      this.div.style.position = 'absolute';
+  	  this.div.style.cursor = 'pointer';
+  	  this.div.style.width = '20px';
+  	  this.div.style.height = '20px';
+      this.getPanes().overlayMouseTarget.appendChild(this.div);
+    };
+
+    CustomMarker.prototype.draw = function draw() {
+      if (this.getMap()) {
+        var point = this.getProjection().fromLatLngToDivPixel(this.latlng);
+      	if (point) {
+          this.div.style.left = (point.x - 10) + 'px';
+    	  this.div.style.top = (point.y - 10) + 'px';
+      	}
+      }
+    };
+
+    CustomMarker.prototype.toggleSelected = function toggleSelected() {
+      this.div.classList.toggle('selected');
+    };
+
+    CustomMarker.prototype.remove = function remove() {
+      if (this.div) {
+        this.div.parentNode.removeChild(this.div);
+        this.div = null;
+      }
+    };
+
+    $scope.customMarker = CustomMarker;
+  });
+</script>
+<script type="text/ng-template" id="custom_markers.html">
+  <div ng-controller="CustomMarkersCtrl">
+    <div>
+      <gm-map gm-map-id="'customMarkers'" gm-center="center"
+              gm-zoom="zoom" gm-map-options="options.map" class="map" id="customMarkers">
+
+        <gm-markers gm-objects="volcanoes2"
+                    gm-id="object.id"
+                    gm-position="{lat: object.location.lat, lng: object.location.lng}"
+                    gm-marker-options="getVolcanoOpts(object)"
+                    gm-on-click="selectVolcano(object, marker)"
+                    gm-marker-constructor="customMarker">
+        </gm-markers>
+
+      </gm-map>
+    </div>
+    <div>
+      <h5 class="muted" ng-show="!volcano">Select a marker!</h5>
+      <div ng-show="volcano">
+        <h5>{{ volcano.name }}, {{ volcano.elevationMeters }}m</h5>
+        <img class="volcano img-rounded" ng-src="{{ volcano.img }}">
+      </div>
+    </div>
+  </div>
+</script>

--- a/src/controllers/angulargmMapController.js
+++ b/src/controllers/angulargmMapController.js
@@ -236,6 +236,22 @@
 
 
     /**
+     * Alias for google.maps.event.addDomListener(object, event, handler)
+     */
+    this.addDomListener = function(object, event, handler) {
+      google.maps.event.addDomListener(object, event, handler);
+    };
+
+
+    /**
+     * Alias for google.maps.event.addDomListenerOnce(object, event, handler)
+     */
+    this.addDomListenerOnce = function(object, event, handler) {
+      google.maps.event.addDomListenerOnce(object, event, handler);
+    };
+
+
+    /**
      * Alias for google.maps.event.trigger(map, event)
      * @param {string} event an event defined on google.maps.Map
      */
@@ -251,9 +267,9 @@
       google.maps.event.trigger(object, event);
     };
 
-    this._newElement = function(type, opts) {
+    this._newElement = function(type, opts, CustomMarkerConstructor) {
         if (type === 'marker') {
-            return new angulargmDefaults.markerConstructor(opts);
+            return angular.isDefined(CustomMarkerConstructor) && angular.isFunction(CustomMarkerConstructor) ? new CustomMarkerConstructor(opts) : new angulargmDefaults.markerConstructor(opts);
         } else if (type === 'polyline') {
             if (!(opts.path instanceof Array)) {
                 throw 'polylineOptions did not contain a path';
@@ -295,7 +311,7 @@
      * @throw if any arguments are null/undefined or elementOptions does not
      *   have all the required options (i.e. position)
      */
-    this.addElement = function(type, scopeId, id, elementOptions, objectsName) {
+    this.addElement = function(type, scopeId, id, elementOptions, objectsName, customMarkerConstructor) {
         assertDefined(type, 'type');
         assertDefined(scopeId, 'scopeId');
         assertDefined(id, 'id');
@@ -319,7 +335,7 @@
         // extend instead of copy to preserve value objects
         var opts = {};
         angular.extend(opts, elementOptions);
-        var element = this._newElement(type, opts);
+        var element = this._newElement(type, opts, customMarkerConstructor);
         elements[scopeId][id] = element;
         element.setMap(this._map);
 

--- a/src/directives/gmMarkers.js
+++ b/src/directives/gmMarkers.js
@@ -86,6 +86,14 @@
  * multiple `gm-on-*event*` handlers, but only one for each type of event.
  * For events that have an underscore in their name, such as
  * 'position_changed', write it as 'gm-on-position-changed'.
+ *
+* @param {expression} gm-marker-constructor an angular expression which evaluates
+ * to a custom marker constructor function. This constructor will be used for all
+ * markers created by this gm-markers directive. If not specified, the default
+ * fromt angulargmDefaults will be used. For example:
+ * ```html
+ * gm-marker-constructor="myCustomMarkerConstructor"
+ * ```
  */
 
 /**
@@ -252,6 +260,7 @@
         gmId: '&',
         gmPosition: '&',
         gmMarkerOptions: '&',
+        gmMarkerConstructor: '=',
         gmEvents: '&'
       },
       require: '^gmMap',

--- a/src/directives/gmMarkers.js
+++ b/src/directives/gmMarkers.js
@@ -88,9 +88,11 @@
  * 'position_changed', write it as 'gm-on-position-changed'.
  *
 * @param {expression} gm-marker-constructor an angular expression which evaluates
- * to a custom marker constructor function. This constructor will be used for all
- * markers created by this gm-markers directive. If not specified, the default
- * fromt angulargmDefaults will be used. For example:
+ * to a custom marker constructor function (presumably based on
+ * [google.maps.OverlayView](https://developers.google.com/maps/documentation/javascript/reference#OverlayView).
+ * This constructor will be used for all markers created by this gm-markers
+ * directive. If not specified, the default from angulargmDefaults will be used.
+ * For example:
  * ```html
  * gm-marker-constructor="myCustomMarkerConstructor"
  * ```

--- a/src/services/angulargmShape.js
+++ b/src/services/angulargmShape.js
@@ -51,7 +51,7 @@
      * Create new shapes and add them to the map for objects which are not
      * currently on the map.
      */
-    function _addNewElements(type, scope, controller, handlers, objectCache, optionsFn, objectsName) {
+    function _addNewElements(type, scope, controller, handlers, objectCache, optionsFn, objectsName, attrs) {
       var added = [];
       angular.forEach(objectCache, function(object, id) {
         var element = controller.getElement(type, scope.$id, id);
@@ -64,7 +64,11 @@
         if (element) {
           controller.updateElement(type, scope.$id, id, options);
         } else {
-          controller.addElement(type, scope.$id, id, options, objectsName);
+          if (type === 'marker' && attrs.gmMarkerConstructor) {
+            controller.addElement(type, scope.$id, id, options, objectsName, scope.gmMarkerConstructor);
+          } else {
+            controller.addElement(type, scope.$id, id, options, objectsName);
+          }
           element = controller.getElement(type, scope.$id, id);
           added.push({
             id: id,
@@ -73,7 +77,7 @@
 
           // set up element event handlers
           angular.forEach(handlers, function(handler, event) {
-            controller.addListener(element, event, function() {
+            function listenerCb() {
               $timeout(function() {
                 var context = {object: object};
                 context[type] = element;
@@ -86,7 +90,19 @@
                   handler(scope.$parent.$parent.$parent , context);
                 }
               });
-            });
+            }
+            if (type === 'marker' && attrs.gmMarkerConstructor) {
+              // nodeType check adapted from Lodash
+              if('getDomElement' in element && element.getDomElement() && element.getDomElement().nodeType === 1) {
+                controller.addDomListener(element.getDomElement(), event, listenerCb);
+              } else {
+                throw 'the constructor provided as gmMarkerConstructor must include a ' +
+                '"getDomElement" method that returns its DOM node, which must exist ' +
+                'after the constructor is called';
+              }
+            } else {
+              controller.addListener(element, event, listenerCb);
+            }
           });
         }
       });
@@ -202,7 +218,7 @@
 
         _addNewElements(
           type, scope, controller, handlers,
-          objectCache, elementOptions, objectsName
+          objectCache, elementOptions, objectsName, attrs
         );
 
         _removeOrphanedElements(type, scope, controller, objectCache, objectsName);


### PR DESCRIPTION
Hey, here's another PR!

In my app, I have a single gmMap with multiple gmMarkers directives. I want to use a custom marker constructor (based on OverlayView) for only one of those sets of markers, so setting angulargmDefaults.markerConstructor doesn't really accomplish what I want.

I extended gmMarkers to accept a custom marker constructor function passed as gmMarkerConstructor. It will apply only to the markers created by that gmMarkers directive.

Here's a basic Plunker: http://plnkr.co/edit/ieC6HIkJMulII5YHMl6A?p=preview

I think this is decent, but there are a few things I want to mention:

### gmMarkersSpec.js:

I'm not super familiar with jasmine and had a lot of trouble here. I added a whole suite of tests for gmMarkerConstructor because my custom marker constructor wasn't getting called at all when I tried follow the pattern used in the "requires the gmPosition attribute" test. It seemed like I needed to do all the element setup, compilation, and controller work before the it() call.

I also struggled to successfully mock my constructor and its prototype methods. The expectations in "is used when a custom marker constructor is provided" kind of beat around the bush because of that. Basically, as soon as I tried to spy on my constructor, it clobbered all my instance methods, and I couldn't seem to get them back.

### angulargmShape.js

I don't like having to inject and use attrs.gmMarkerConstructor to test whether someone passed a constructor, but scope.gmMarkerConstructor exists and is a function no matter what thanks to Angular.

I don't like having two separate calls to controller.addElement in _addNewElements, but using a single one and passing an undefined custom constructor as the last argument would have required a major rework of tests that check what arguments are passed to the controller's addElement function. It wouldn't be so bad to update all the tests once, but it seemed like it would create a fair bit of frustration with any future updates/tests.

Requiring the custom constructor to have a "getDomElement" method and the test to verify that it returns a DOM node seem a little cludgy, but I think it is necessary since OverlayView events need to use addDomListener rather than just addListener, and that requires passing the appropriate DOM node (not the marker) as the object when creating the listener.



I'm happy to make changes if you have suggestions about any of this stuff.

Thanks for considering the PR and all your work on AngularGM!